### PR TITLE
Add dev AI respond route and smoke test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "tomchat-v2",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@eslint/js": "^9.35.0",
         "@prisma/client": "^5.18.0",
@@ -40,6 +41,7 @@
         "nodemon": "^3.1.0",
         "prettier": "^3.2.5",
         "prisma": "^5.18.0",
+        "supertest": "^7.1.4",
         "ts-node": "^10.9.2",
         "tsc-alias": "^1.8.10",
         "tsx": "^4.16.0",
@@ -871,6 +873,19 @@
         "win32"
       ]
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -907,6 +922,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgr/core": {
@@ -2176,6 +2201,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -2613,6 +2645,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2661,6 +2703,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -2882,6 +2931,17 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -3808,6 +3868,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -3984,6 +4051,24 @@
       },
       "engines": {
         "node": ">= 12.20"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -7252,6 +7337,54 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "nodemon": "^3.1.0",
     "prettier": "^3.2.5",
     "prisma": "^5.18.0",
+    "supertest": "^7.1.4",
     "ts-node": "^10.9.2",
     "tsc-alias": "^1.8.10",
     "tsx": "^4.16.0",

--- a/src/__tests__/dev.ai.routes.test.ts
+++ b/src/__tests__/dev.ai.routes.test.ts
@@ -1,0 +1,28 @@
+import request from 'supertest';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { buildTestApp } from '@test/utils/buildTestApp.js';
+
+process.env.NODE_ENV = process.env.NODE_ENV ?? 'test';
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgresql://test:test@localhost:5432/test';
+process.env.REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379';
+
+describe('dev AI routes', () => {
+  let app: ReturnType<typeof buildTestApp> | null = null;
+
+  beforeAll(async () => {
+    const { default: devAiRoutes } = await import('@api/routes/dev.ai.routes.js');
+    app = buildTestApp(devAiRoutes);
+  });
+
+  it('responds to POST /dev/ai/respond', async () => {
+    const response = await request(app!).post('/v1/dev/ai/respond').send({
+      tenantId: 'tenant-test',
+      userPhone: '+390000000000',
+      text: 'ciao',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.replyText).toBe('echo: ciao');
+  });
+});

--- a/src/api/routes/dev.ai.routes.ts
+++ b/src/api/routes/dev.ai.routes.ts
@@ -1,0 +1,67 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import type { WAEvent } from '@types/index.js';
+
+import { EnhancedNLUService } from '@services/ai/nlu.service.js';
+import { ConversationService } from '@services/conversation/conversation.service.js';
+
+import { prisma } from '@infra/database/prisma.client.js';
+
+const router = Router();
+
+if (process.env.NODE_ENV !== 'production') {
+  const conversation = new ConversationService();
+
+  router.post('/dev/ai/respond', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { tenantId, userPhone, text } = req.body ?? {};
+      if (!tenantId || !userPhone || !text) {
+        return res.status(400).json({ message: 'tenantId, userPhone and text are required' });
+      }
+
+      let tenant: any = null;
+      let tenantError: string | undefined;
+      try {
+        tenant = await (prisma as any).tenant.findUnique({ where: { id: tenantId } });
+      } catch (err) {
+        tenantError = err instanceof Error ? err.message : 'tenant_lookup_failed';
+      }
+
+      const fallbackTenant = tenant ?? {
+        id: tenantId,
+        name: tenantId,
+        timezone: 'Europe/Rome',
+        config: {},
+        features: {},
+      };
+
+      let nlu: unknown = null;
+      let nluError: string | undefined;
+      try {
+        const nluService = new EnhancedNLUService();
+        nlu = await nluService.parseWithContext(text, null, fallbackTenant as any);
+      } catch (err) {
+        nluError = err instanceof Error ? err.message : 'nlu_unavailable';
+      }
+
+      const event: WAEvent = {
+        tenantId,
+        userPhone,
+        message: text,
+        messageId: req.body?.messageId ?? `dev-${Date.now().toString(36)}`,
+      };
+      const { replyText } = await conversation.processMessage(event);
+
+      const payload: Record<string, unknown> = { replyText };
+      if (nlu) payload.nlu = nlu;
+      if (nluError) payload.nluError = nluError;
+      if (!tenant && !tenantError) payload.tenantFound = false;
+      if (tenantError) payload.tenantError = tenantError;
+
+      res.json(payload);
+    } catch (err) {
+      next(err);
+    }
+  });
+}
+
+export default router;

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -5,6 +5,7 @@ import webhookRoutes from './webhook.routes.js';
 import devRoutes from './dev.routes.js';
 import devAvailabilityRoutes from './dev.availability.routes.js';
 import devNluRoutes from './dev.nlu.routes.js';
+import devAiRoutes from './dev.ai.routes.js';
 
 const v1Router = Router();
 v1Router.use(healthRoutes);
@@ -13,6 +14,7 @@ if (process.env.NODE_ENV !== 'production') {
   v1Router.use(devRoutes);
   v1Router.use(devAvailabilityRoutes);
   v1Router.use(devNluRoutes);
+  v1Router.use(devAiRoutes);
 }
 
 const router = Router();


### PR DESCRIPTION
## Summary
- add a development-only /dev/ai/respond endpoint delegating to the conversation pipeline with optional NLU parsing
- register the new router in the v1 dev scope and cover it with a Vitest supertest smoke test
- add supertest as a dev dependency for the HTTP test helper

## Testing
- DATABASE_URL="postgresql://postgres:postgres@localhost:5432/tomchat" REDIS_URL="redis://localhost:6379" OPENAI_API_KEY="sk-test" OPENAI_MODEL="gpt-4o-mini" OPENAI_TEMPERATURE="0.2" npm test *(fails: requires a PostgreSQL instance on localhost:5432 for Prisma-backed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0aa1e8d883289a495db37caafe77